### PR TITLE
HU-1: Register user endpoint

### DIFF
--- a/applications/app-service/build.gradle
+++ b/applications/app-service/build.gradle
@@ -1,6 +1,9 @@
 apply plugin: 'org.springframework.boot'
 
 dependencies {
+	implementation project(':reactive-web')
+	implementation 'org.reactivecommons.utils:object-mapper:0.1.0'
+	implementation project(':r2dbc-postgresql')
     implementation project(':model')
     implementation project(':usecase')
     implementation 'org.springframework.boot:spring-boot-starter'
@@ -23,4 +26,3 @@ bootJar {
     // Sets output jar name
     archiveFileName = "${project.getParent().getName()}.${archiveExtension.get()}"
 }
-

--- a/applications/app-service/src/main/java/com/crediya/config/ObjectMapperConfig.java
+++ b/applications/app-service/src/main/java/com/crediya/config/ObjectMapperConfig.java
@@ -1,0 +1,16 @@
+package com.crediya.config;
+
+import org.reactivecommons.utils.ObjectMapper;
+import org.reactivecommons.utils.ObjectMapperImp;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class ObjectMapperConfig {
+
+	@Bean
+	public ObjectMapper objectMapper() {
+		return new ObjectMapperImp();
+	}
+
+}

--- a/applications/app-service/src/main/java/com/crediya/config/UseCasesConfig.java
+++ b/applications/app-service/src/main/java/com/crediya/config/UseCasesConfig.java
@@ -1,14 +1,17 @@
 package com.crediya.config;
 
+import com.crediya.model.user.UserValidator;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.FilterType;
 
 @Configuration
-@ComponentScan(basePackages = "com.crediya.usecase",
-        includeFilters = {
-                @ComponentScan.Filter(type = FilterType.REGEX, pattern = "^.+UseCase$")
-        },
-        useDefaultFilters = false)
+@ComponentScan(basePackages = "com.crediya.usecase", includeFilters = {
+ @ComponentScan.Filter(type = FilterType.REGEX, pattern = "^.+UseCase$")}, useDefaultFilters = false)
 public class UseCasesConfig {
+	@Bean
+	public UserValidator userValidator() {
+		return new UserValidator();
+	}
 }

--- a/applications/app-service/src/main/resources/application.yaml
+++ b/applications/app-service/src/main/resources/application.yaml
@@ -1,14 +1,37 @@
-##Spring Configuration
 server:
   port: 8080
 spring:
   application:
-    name: authentication
+    name: "authentication"
   devtools:
     add-properties: false
   h2:
     console:
       enabled: true
-      path: /h2
+      path: "/h2"
   profiles:
-    include:
+    include: null
+management:
+  endpoints:
+    web:
+      exposure:
+        include: "health,prometheus"
+  endpoint:
+    health:
+      probes:
+        enabled: true
+cors:
+  allowed-origins: "http://localhost:4200,http://localhost:8080"
+
+routes:
+  paths:
+    user: "/api/v1/users"
+
+adapters:
+  r2dbc:
+    host: "aws-1-us-east-1.pooler.supabase.com"
+    port: 5432
+    database: "postgres"
+    schema: "public"
+    username: "postgres.quzntnzcjtjznzqheqqo"
+    password: "mbCuQpzt8TowU"

--- a/applications/app-service/src/test/java/com/crediya/config/ObjectMapperConfigTest.java
+++ b/applications/app-service/src/test/java/com/crediya/config/ObjectMapperConfigTest.java
@@ -1,0 +1,20 @@
+package com.crediya.config;
+
+import org.junit.jupiter.api.Test;
+import org.reactivecommons.utils.ObjectMapper;
+import org.reactivecommons.utils.ObjectMapperImp;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ObjectMapperConfigTest {
+
+    @Test
+    void testObjectMapperBean() {
+        AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext(ObjectMapperConfig.class);
+        ObjectMapper objectMapper = context.getBean(ObjectMapper.class);
+        assertNotNull(objectMapper);
+        assertTrue(objectMapper instanceof ObjectMapperImp);
+        context.close();
+    }
+}

--- a/applications/app-service/src/test/java/com/crediya/config/UseCasesConfigTest.java
+++ b/applications/app-service/src/test/java/com/crediya/config/UseCasesConfigTest.java
@@ -1,13 +1,16 @@
 package com.crediya.config;
 
+import com.crediya.model.user.gateways.UserRepository;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
+
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class UseCasesConfigTest {
+class UseCasesConfigTest {
 
     @Test
     void testUseCaseBeansExist() {
@@ -33,6 +36,11 @@ public class UseCasesConfigTest {
         @Bean
         public MyUseCase myUseCase() {
             return new MyUseCase();
+        }
+
+        @Bean
+        public UserRepository taskRepository() {
+            return Mockito.mock(UserRepository.class);
         }
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -6,6 +6,7 @@ buildscript {
 		jacocoVersion = '0.8.13'
 		pitestVersion = '1.19.0-rc.1'
         lombokVersion = '1.18.38'
+        mapstructVersion = '1.6.3'
 	}
 }
 

--- a/domain/model/src/main/java/com/crediya/model/user/User.java
+++ b/domain/model/src/main/java/com/crediya/model/user/User.java
@@ -1,0 +1,26 @@
+package com.crediya.model.user;
+import lombok.Builder;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder(toBuilder = true)
+public class User {
+	private Long id;
+	private String documentNumber;
+	private String name;
+	private String lastName;
+	private LocalDate birthDate;
+	private String address;
+	private String phone;
+	private String email;
+	private BigDecimal baseSalary;
+}

--- a/domain/model/src/main/java/com/crediya/model/user/UserValidator.java
+++ b/domain/model/src/main/java/com/crediya/model/user/UserValidator.java
@@ -1,0 +1,81 @@
+package com.crediya.model.user;
+
+import com.crediya.model.user.exceptions.ValidationException;
+import reactor.core.publisher.Mono;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+public class UserValidator {
+	private static final String EMAIL_PATTERN = "^[A-Za-z0-9+_.-]+@(.+)$";
+	private static final BigDecimal MIN_SALARY = BigDecimal.ZERO;
+	private static final BigDecimal MAX_SALARY = new BigDecimal("15000000");
+
+	public Mono<Void> validateUser(User user) {
+		return Mono.fromRunnable(() -> {
+			validateRequiredFields(user);
+			validateBirthDate(user.getBirthDate());
+			validateEmailFormat(user.getEmail());
+			validateSalaryRange(user.getBaseSalary());
+			validateDocumentNumber(user.getDocumentNumber());
+		});
+	}
+
+	private void validateRequiredFields(User user) {
+		if (isNullOrEmpty(user.getName())) {
+			throw new ValidationException("Name is required.");
+		}
+		if (isNullOrEmpty(user.getLastName())) {
+			throw new ValidationException("Last name is required.");
+		}
+		if (user.getBirthDate() == null) {
+			throw new ValidationException("Birthdate is required.");
+		}
+		if (isNullOrEmpty(user.getAddress())) {
+			throw new ValidationException("Address is required.");
+		}
+		if (isNullOrEmpty(user.getPhone())) {
+			throw new ValidationException("Phone is required.");
+		}
+		if (isNullOrEmpty(user.getEmail())) {
+			throw new ValidationException("Email is required.");
+		}
+		if (user.getBaseSalary() == null) {
+			throw new ValidationException("Base salary is required.");
+		}
+		if (isNullOrEmpty(user.getDocumentNumber())) {
+			throw new ValidationException("Document number is required.");
+		}
+	}
+
+	private void validateEmailFormat(String email) {
+		if (!email.matches(EMAIL_PATTERN)) {
+			throw new ValidationException("Email format is invalid");
+		}
+	}
+
+	private void validateSalaryRange(BigDecimal salary) {
+		if (salary.compareTo(MIN_SALARY) <= 0 || salary.compareTo(MAX_SALARY) > 0) {
+			throw new ValidationException("Salary must be between 0 and 15,000,000");
+		}
+	}
+
+	private void validateDocumentNumber(String documentNumber) {
+		if (documentNumber.length() != 8 || !documentNumber.matches("\\d+")) {
+			throw new ValidationException("Document number must be numeric and up to 8 digits long");
+		}
+	}
+
+	private boolean isNullOrEmpty(String value) {
+		return value == null || value.trim().isEmpty();
+	}
+
+	private void validateBirthDate(LocalDate birthDate) {
+		if (birthDate.isAfter(LocalDate.now())) {
+			throw new ValidationException("Birthdate cannot be in the future");
+		}
+		if (birthDate.isBefore(LocalDate.now().minusYears(120))) {
+			throw new ValidationException("Birthdate cannot be more than 120 years ago");
+		}
+	}
+}

--- a/domain/model/src/main/java/com/crediya/model/user/exceptions/ValidationException.java
+++ b/domain/model/src/main/java/com/crediya/model/user/exceptions/ValidationException.java
@@ -1,0 +1,7 @@
+package com.crediya.model.user.exceptions;
+
+public class ValidationException extends RuntimeException {
+    public ValidationException(String message) {
+        super(message);
+    }
+}

--- a/domain/model/src/main/java/com/crediya/model/user/gateways/UserRepository.java
+++ b/domain/model/src/main/java/com/crediya/model/user/gateways/UserRepository.java
@@ -1,0 +1,12 @@
+package com.crediya.model.user.gateways;
+
+import com.crediya.model.user.User;
+import reactor.core.publisher.Mono;
+
+public interface UserRepository {
+	Mono<User> save(User user);
+
+	Mono<Boolean> existsByEmail(String email);
+
+	Mono<Boolean> existsByDocumentNumber(String documentNumber);
+}

--- a/domain/model/src/test/java/com/crediya/model/user/UserTest.java
+++ b/domain/model/src/test/java/com/crediya/model/user/UserTest.java
@@ -1,0 +1,154 @@
+package com.crediya.model.user;
+
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class UserTest {
+
+	@Test
+	void shouldCreateUserWithBuilder() {
+		LocalDate birthDate = LocalDate.of(1990, 1, 1);
+		BigDecimal baseSalary = BigDecimal.valueOf(5000000);
+
+		User user = User.builder().id(1L).documentNumber("12345678").name("John").lastName("Doe").birthDate(birthDate)
+		 .address("123 Main St").phone("1234567890").email("john.doe@example.com").baseSalary(baseSalary).build();
+
+		assertEquals(1L, user.getId());
+		assertEquals("12345678", user.getDocumentNumber());
+		assertEquals("John", user.getName());
+		assertEquals("Doe", user.getLastName());
+		assertEquals(birthDate, user.getBirthDate());
+		assertEquals("123 Main St", user.getAddress());
+		assertEquals("1234567890", user.getPhone());
+		assertEquals("john.doe@example.com", user.getEmail());
+		assertEquals(baseSalary, user.getBaseSalary());
+	}
+
+	@Test
+	void shouldCreateUserWithNoArgsConstructor() {
+		User user = new User();
+		assertNotNull(user);
+		assertNull(user.getId());
+		assertNull(user.getName());
+		assertNull(user.getLastName());
+		assertNull(user.getBirthDate());
+		assertNull(user.getAddress());
+		assertNull(user.getPhone());
+		assertNull(user.getEmail());
+		assertNull(user.getBaseSalary());
+		assertNull(user.getDocumentNumber());
+	}
+
+	@Test
+	void shouldCreateUserWithAllArgsConstructor() {
+		LocalDate birthDate = LocalDate.of(1990, 1, 1);
+		BigDecimal baseSalary = BigDecimal.valueOf(5000000);
+
+		User user =
+		 new User(1L, "12345678", "John", "Doe", birthDate, "123 Main St", "1234567890", "john.doe@example.com",
+			baseSalary);
+
+		assertEquals(1L, user.getId());
+		assertEquals("12345678", user.getDocumentNumber());
+		assertEquals("John", user.getName());
+		assertEquals("Doe", user.getLastName());
+		assertEquals(birthDate, user.getBirthDate());
+		assertEquals("123 Main St", user.getAddress());
+		assertEquals("1234567890", user.getPhone());
+		assertEquals("john.doe@example.com", user.getEmail());
+		assertEquals(baseSalary, user.getBaseSalary());
+	}
+
+	@Test
+	void shouldModifyUserWithSetters() {
+		User user = new User();
+		LocalDate birthDate = LocalDate.of(1990, 1, 1);
+		BigDecimal baseSalary = BigDecimal.valueOf(5000000);
+
+		user.setId(1L);
+		user.setDocumentNumber("12345678");
+		user.setName("John");
+		user.setLastName("Doe");
+		user.setBirthDate(birthDate);
+		user.setAddress("123 Main St");
+		user.setPhone("1234567890");
+		user.setEmail("john.doe@example.com");
+		user.setBaseSalary(baseSalary);
+
+		assertEquals(1L, user.getId());
+		assertEquals("12345678", user.getDocumentNumber());
+		assertEquals("John", user.getName());
+		assertEquals("Doe", user.getLastName());
+		assertEquals(birthDate, user.getBirthDate());
+		assertEquals("123 Main St", user.getAddress());
+		assertEquals("1234567890", user.getPhone());
+		assertEquals("john.doe@example.com", user.getEmail());
+		assertEquals(baseSalary, user.getBaseSalary());
+	}
+
+	@Test
+	void shouldCreateNewInstanceWithToBuilder() {
+		User originalUser =
+		 User.builder().id(1L).documentNumber("12345678").name("John").lastName("Doe").birthDate(LocalDate.of(1990, 1, 1))
+			.address("123 Main St").phone("1234567890").email("john.doe@example.com").baseSalary(BigDecimal.valueOf(5000000))
+			.build();
+
+		User modifiedUser = originalUser.toBuilder().name("Jane").email("jane.doe@example.com").build();
+
+		assertEquals("Jane", modifiedUser.getName());
+		assertEquals("jane.doe@example.com", modifiedUser.getEmail());
+		assertEquals(originalUser.getId(), modifiedUser.getId());
+		assertEquals(originalUser.getLastName(), modifiedUser.getLastName());
+		assertEquals(originalUser.getBirthDate(), modifiedUser.getBirthDate());
+		assertEquals(originalUser.getAddress(), modifiedUser.getAddress());
+		assertEquals(originalUser.getPhone(), modifiedUser.getPhone());
+		assertEquals(originalUser.getBaseSalary(), modifiedUser.getBaseSalary());
+		assertEquals(originalUser.getDocumentNumber(), modifiedUser.getDocumentNumber());
+
+		assertEquals("John", originalUser.getName());
+		assertEquals("john.doe@example.com", originalUser.getEmail());
+	}
+
+	@Test
+	void shouldHandleNullValues() {
+		User user =
+		 User.builder().id(null).documentNumber(null).name(null).lastName(null).birthDate(null).address(null).phone(null)
+			.email(null).baseSalary(null).build();
+
+		assertNull(user.getId());
+		assertNull(user.getDocumentNumber());
+		assertNull(user.getName());
+		assertNull(user.getLastName());
+		assertNull(user.getBirthDate());
+		assertNull(user.getAddress());
+		assertNull(user.getPhone());
+		assertNull(user.getEmail());
+		assertNull(user.getBaseSalary());
+	}
+
+	@Test
+	void shouldCreateBuilderFromExistingUser() {
+		User originalUser =
+		 User.builder().id(1L).documentNumber("12345678").name("John").lastName("Doe").birthDate(LocalDate.of(1990, 1, 1))
+			.address("123 Main St").phone("1234567890").email("john.doe@example.com").baseSalary(BigDecimal.valueOf(5000000))
+			.build();
+
+		User newUser = originalUser.toBuilder().build();
+
+		assertEquals(originalUser.getId(), newUser.getId());
+		assertEquals(originalUser.getDocumentNumber(), newUser.getDocumentNumber());
+		assertEquals(originalUser.getName(), newUser.getName());
+		assertEquals(originalUser.getLastName(), newUser.getLastName());
+		assertEquals(originalUser.getBirthDate(), newUser.getBirthDate());
+		assertEquals(originalUser.getAddress(), newUser.getAddress());
+		assertEquals(originalUser.getPhone(), newUser.getPhone());
+		assertEquals(originalUser.getEmail(), newUser.getEmail());
+		assertEquals(originalUser.getBaseSalary(), newUser.getBaseSalary());
+
+		assertNotSame(originalUser, newUser);
+	}
+}

--- a/domain/usecase/src/main/java/com/crediya/usecase/user/UserUseCase.java
+++ b/domain/usecase/src/main/java/com/crediya/usecase/user/UserUseCase.java
@@ -1,0 +1,23 @@
+package com.crediya.usecase.user;
+
+import com.crediya.model.user.User;
+import com.crediya.model.user.UserValidator;
+import com.crediya.model.user.exceptions.ValidationException;
+import com.crediya.model.user.gateways.UserRepository;
+import reactor.core.publisher.Mono;
+
+public record UserUseCase(UserRepository userRepository, UserValidator userValidator) {
+	public Mono<User> save(User user) {
+		return userValidator.validateUser(user).then(Mono.defer(() -> validateUniqueConstraints(user)))
+		 .then(Mono.defer(() -> userRepository.save(user)));
+	}
+
+	private Mono<Void> validateUniqueConstraints(User user) {
+		return Mono.defer(() -> Mono.when(userRepository.existsByEmail(user.getEmail())
+		 .flatMap(exists -> Boolean.TRUE.equals(exists) ?
+			Mono.error(new ValidationException("Email is already registered")) :
+			Mono.empty()), userRepository.existsByDocumentNumber(user.getDocumentNumber())
+		 .flatMap(exists -> Boolean.TRUE.equals(exists) ?
+			Mono.error(new ValidationException("Document number is already registered")) : Mono.empty())));
+	}
+}

--- a/domain/usecase/src/test/java/com/crediya/usecase/user/UserUseCaseTest.java
+++ b/domain/usecase/src/test/java/com/crediya/usecase/user/UserUseCaseTest.java
@@ -1,0 +1,134 @@
+package com.crediya.usecase.user;
+
+import com.crediya.model.user.User;
+import com.crediya.model.user.UserValidator;
+import com.crediya.model.user.exceptions.ValidationException;
+import com.crediya.model.user.gateways.UserRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class UserUseCaseTest {
+
+	@Mock
+	private UserRepository userRepository;
+
+	@Mock
+	private UserValidator userValidator;
+
+	@InjectMocks
+	private UserUseCase userUseCase;
+
+	@Test
+	void shouldSaveUserSuccessfully() {
+		User user = createValidUser();
+		User savedUser = user.toBuilder().id(1L).build();
+
+		when(userValidator.validateUser(any(User.class))).thenReturn(Mono.empty());
+		when(userRepository.existsByEmail(anyString())).thenReturn(Mono.just(false));
+		when(userRepository.existsByDocumentNumber(anyString())).thenReturn(Mono.just(false));
+		when(userRepository.save(any(User.class))).thenReturn(Mono.just(savedUser));
+
+		Mono<User> result = userUseCase.save(user);
+
+		StepVerifier.create(result).expectNext(savedUser).verifyComplete();
+	}
+
+	@Test
+	void shouldFailWhenValidationFails() {
+		User user = createValidUser();
+
+		when(userValidator.validateUser(any(User.class))).thenReturn(Mono.error(new ValidationException("Name is required")));
+
+		Mono<User> result = userUseCase.save(user);
+
+		StepVerifier.create(result).expectError(ValidationException.class).verify();
+	}
+
+	@Test
+	void shouldFailWhenEmailAlreadyExists() {
+		User user = createValidUser();
+
+		when(userValidator.validateUser(any(User.class))).thenReturn(Mono.empty());
+		when(userRepository.existsByEmail(user.getEmail())).thenReturn(Mono.just(true));
+		when(userRepository.existsByDocumentNumber(anyString())).thenReturn(Mono.just(false));
+
+		Mono<User> result = userUseCase.save(user);
+
+		StepVerifier.create(result).expectErrorMatches(throwable -> throwable instanceof ValidationException &&
+		 throwable.getMessage().equals("Email is already registered")).verify();
+	}
+
+	@Test
+	void shouldFailWhenDocumentNumberAlreadyExists() {
+		User user = createValidUser();
+
+		when(userValidator.validateUser(any(User.class))).thenReturn(Mono.empty());
+		when(userRepository.existsByEmail(anyString())).thenReturn(Mono.just(false));
+		when(userRepository.existsByDocumentNumber(user.getDocumentNumber())).thenReturn(Mono.just(true));
+
+		Mono<User> result = userUseCase.save(user);
+
+		StepVerifier.create(result).expectErrorMatches(throwable -> throwable instanceof ValidationException &&
+		 throwable.getMessage().equals("Document number is already registered")).verify();
+	}
+
+	@Test
+	void shouldFailWhenRepositorySaveFails() {
+		User user = createValidUser();
+
+		when(userValidator.validateUser(any(User.class))).thenReturn(Mono.empty());
+		when(userRepository.existsByEmail(anyString())).thenReturn(Mono.just(false));
+		when(userRepository.existsByDocumentNumber(anyString())).thenReturn(Mono.just(false));
+		when(userRepository.save(any(User.class))).thenReturn(Mono.error(new RuntimeException("Database error")));
+
+		Mono<User> result = userUseCase.save(user);
+
+		StepVerifier.create(result).expectError(RuntimeException.class).verify();
+	}
+
+	@Test
+	void shouldHandleRepositoryExistsMethodErrors() {
+		User user = createValidUser();
+
+		when(userValidator.validateUser(any(User.class))).thenReturn(Mono.empty());
+		when(userRepository.existsByEmail(anyString())).thenReturn(Mono.error(new RuntimeException("Database connection " +
+		 "error")));
+
+		Mono<User> result = userUseCase.save(user);
+
+		StepVerifier.create(result).expectError(RuntimeException.class).verify();
+	}
+
+	@Test
+	void shouldContinueWhenEmailCheckPassesButDocumentCheckFails() {
+		User user = createValidUser();
+
+		when(userValidator.validateUser(any(User.class))).thenReturn(Mono.empty());
+		when(userRepository.existsByEmail(anyString())).thenReturn(Mono.just(false));
+		when(userRepository.existsByDocumentNumber(anyString())).thenReturn(Mono.error(new RuntimeException("Database " +
+		 "error")));
+
+		Mono<User> result = userUseCase.save(user);
+
+		StepVerifier.create(result).expectError(RuntimeException.class).verify();
+	}
+
+	private User createValidUser() {
+		return User.builder().documentNumber("12345678").name("John").lastName("Doe").birthDate(LocalDate.of(1990, 1, 1))
+		 .address("123 Main St").phone("1234567890").email("john.doe@example.com").baseSalary(BigDecimal.valueOf(5000000))
+		 .build();
+	}
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,12 +1,14 @@
-package=com.crediya
-systemProp.version=3.24.0
-reactive=true
+#Tue Aug 26 20:18:49 GMT-05:00 2025
+analytics=false
+language=java
 lombok=true
 metrics=true
-language=java
-org.gradle.parallel=true
 org.gradle.caching=true
 org.gradle.configuration-cache=true
-org.gradle.configuration-cache.parallel=true
 org.gradle.configuration-cache.integrity-check=true
+org.gradle.configuration-cache.parallel=true
+org.gradle.parallel=true
+package=com.crediya
+reactive=true
 systemProp.sonar.gradle.skipCompile=true
+systemProp.version=3.24.0

--- a/infrastructure/driven-adapters/r2dbc-postgresql/build.gradle
+++ b/infrastructure/driven-adapters/r2dbc-postgresql/build.gradle
@@ -1,0 +1,11 @@
+dependencies {
+    implementation project(':model')
+    implementation 'org.springframework:spring-context'
+    implementation 'org.springframework.boot:spring-boot-starter-data-r2dbc'
+    implementation 'jakarta.persistence:jakarta.persistence-api' // TODO: Check if it's still necessary
+    implementation 'org.postgresql:r2dbc-postgresql'
+    implementation 'org.reactivecommons.utils:object-mapper-api:0.1.0'
+
+    testImplementation 'org.reactivecommons.utils:object-mapper:0.1.0'
+}
+

--- a/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/com/crediya/r2dbc/IUserRepository.java
+++ b/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/com/crediya/r2dbc/IUserRepository.java
@@ -1,0 +1,13 @@
+package com.crediya.r2dbc;
+
+import com.crediya.r2dbc.entity.UserEntity;
+import org.springframework.data.repository.query.ReactiveQueryByExampleExecutor;
+import org.springframework.data.repository.reactive.ReactiveCrudRepository;
+import reactor.core.publisher.Mono;
+
+public interface IUserRepository extends ReactiveCrudRepository<UserEntity, Long>,
+ ReactiveQueryByExampleExecutor<UserEntity> {
+	Mono<Boolean> existsByEmail(String email);
+
+	Mono<Boolean> existsByDocumentNumber(String documentNumber);
+}

--- a/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/com/crediya/r2dbc/UserRepositoryAdapter.java
+++ b/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/com/crediya/r2dbc/UserRepositoryAdapter.java
@@ -1,0 +1,39 @@
+package com.crediya.r2dbc;
+
+import com.crediya.model.user.User;
+import com.crediya.model.user.gateways.UserRepository;
+import com.crediya.r2dbc.entity.UserEntity;
+import com.crediya.r2dbc.helper.ReactiveAdapterOperations;
+import lombok.extern.log4j.Log4j2;
+import org.reactivecommons.utils.ObjectMapper;
+import org.springframework.stereotype.Repository;
+import reactor.core.publisher.Mono;
+
+@Log4j2
+@Repository
+public class UserRepositoryAdapter extends ReactiveAdapterOperations<User, UserEntity, Long, IUserRepository> implements UserRepository {
+	public UserRepositoryAdapter(IUserRepository repository, ObjectMapper mapper) {
+		super(repository, mapper, d -> mapper.map(d, User.class));
+	}
+
+	@Override
+	public Mono<User> save(User user) {
+		if (user == null) {
+			return Mono.error(new IllegalArgumentException("User cannot be null"));
+		}
+		log.info("Saving user in the database");
+		return super.save(user);
+	}
+
+	@Override
+	public Mono<Boolean> existsByEmail(String email) {
+		log.info("Validating if email is already registered in the database");
+		return repository.existsByEmail(email);
+	}
+
+	@Override
+	public Mono<Boolean> existsByDocumentNumber(String documentNumber) {
+		log.info("Validating if document number is already registered in the database");
+		return repository.existsByDocumentNumber(documentNumber);
+	}
+}

--- a/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/com/crediya/r2dbc/config/PostgreSQLConnectionPool.java
+++ b/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/com/crediya/r2dbc/config/PostgreSQLConnectionPool.java
@@ -1,0 +1,42 @@
+package com.crediya.r2dbc.config;
+
+import io.r2dbc.pool.ConnectionPool;
+import io.r2dbc.pool.ConnectionPoolConfiguration;
+import io.r2dbc.postgresql.PostgresqlConnectionConfiguration;
+import io.r2dbc.postgresql.PostgresqlConnectionFactory;
+import io.r2dbc.postgresql.client.SSLMode;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.time.Duration;
+
+@Configuration
+public class PostgreSQLConnectionPool {
+    public static final int INITIAL_SIZE = 12;
+    public static final int MAX_SIZE = 15;
+    public static final int MAX_IDLE_TIME = 30;
+
+	@Bean
+	public ConnectionPool getConnectionConfig(PostgresqlConnectionProperties properties) {
+		PostgresqlConnectionConfiguration dbConfiguration = PostgresqlConnectionConfiguration.builder()
+                .host(properties.host())
+                .port(properties.port())
+                .database(properties.database())
+                .schema(properties.schema())
+                .username(properties.username())
+                .password(properties.password())
+		 						.sslMode(SSLMode.REQUIRE)
+                .build();
+
+        ConnectionPoolConfiguration poolConfiguration = ConnectionPoolConfiguration.builder()
+                .connectionFactory(new PostgresqlConnectionFactory(dbConfiguration))
+                .name("api-postgres-connection-pool")
+                .initialSize(INITIAL_SIZE)
+                .maxSize(MAX_SIZE)
+                .maxIdleTime(Duration.ofMinutes(MAX_IDLE_TIME))
+                .validationQuery("SELECT 1")
+                .build();
+
+		return new ConnectionPool(poolConfiguration);
+	}
+}

--- a/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/com/crediya/r2dbc/config/PostgresqlConnectionProperties.java
+++ b/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/com/crediya/r2dbc/config/PostgresqlConnectionProperties.java
@@ -1,0 +1,13 @@
+package com.crediya.r2dbc.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "adapters.r2dbc")
+public record PostgresqlConnectionProperties(
+        String host,
+        Integer port,
+        String database,
+        String schema,
+        String username,
+        String password) {
+}

--- a/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/com/crediya/r2dbc/entity/UserEntity.java
+++ b/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/com/crediya/r2dbc/entity/UserEntity.java
@@ -1,0 +1,42 @@
+package com.crediya.r2dbc.entity;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.relational.core.mapping.Column;
+import org.springframework.data.relational.core.mapping.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+@Table("users")
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+@Builder
+public class UserEntity {
+	@Id
+	private Long id;
+
+	@Column("document_number")
+	private String documentNumber;
+
+	private String name;
+
+	@Column("last_name")
+	private String lastName;
+
+	@Column("birth_date")
+	private LocalDate birthDate;
+
+	private String address;
+	private String phone;
+	private String email;
+
+	@Column("base_salary")
+	private BigDecimal baseSalary;
+}

--- a/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/com/crediya/r2dbc/helper/ReactiveAdapterOperations.java
+++ b/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/com/crediya/r2dbc/helper/ReactiveAdapterOperations.java
@@ -1,0 +1,67 @@
+package com.crediya.r2dbc.helper;
+
+import org.reactivecommons.utils.ObjectMapper;
+import org.springframework.data.domain.Example;
+import org.springframework.data.repository.query.ReactiveQueryByExampleExecutor;
+import org.springframework.data.repository.reactive.ReactiveCrudRepository;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.lang.reflect.ParameterizedType;
+import java.util.function.Function;
+
+public abstract class ReactiveAdapterOperations<E, D, I, R extends ReactiveCrudRepository<D, I> & ReactiveQueryByExampleExecutor<D>> {
+    protected R repository;
+    protected ObjectMapper mapper;
+    private final Class<D> dataClass;
+    private final Function<D, E> toEntityFn;
+
+    @SuppressWarnings("unchecked")
+    protected ReactiveAdapterOperations(R repository, ObjectMapper mapper, Function<D, E> toEntityFn) {
+        this.repository = repository;
+        this.mapper = mapper;
+        ParameterizedType genericSuperclass = (ParameterizedType) this.getClass().getGenericSuperclass();
+        this.dataClass = (Class<D>) genericSuperclass.getActualTypeArguments()[1];
+        this.toEntityFn = toEntityFn;
+    }
+
+    protected D toData(E entity) {
+        return mapper.map(entity, dataClass);
+    }
+
+    protected E toEntity(D data) {
+        return data != null ? toEntityFn.apply(data) : null;
+    }
+
+    public Mono<E> save(E entity) {
+        return saveData(toData(entity))
+                .map(this::toEntity);
+    }
+
+    protected Flux<E> saveAllEntities(Flux<E> entities) {
+        return saveData(entities.map(this::toData))
+                .map(this::toEntity);
+    }
+
+    protected Mono<D> saveData(D data) {
+        return repository.save(data);
+    }
+
+    protected Flux<D> saveData(Flux<D> data) {
+        return repository.saveAll(data);
+    }
+
+    public Mono<E> findById(I id) {
+        return repository.findById(id).map(this::toEntity);
+    }
+
+    public Flux<E> findByExample(E entity) {
+        return repository.findAll(Example.of(toData(entity)))
+                .map(this::toEntity);
+    }
+
+    public Flux<E> findAll() {
+        return repository.findAll()
+                .map(this::toEntity);
+    }
+}

--- a/infrastructure/driven-adapters/r2dbc-postgresql/src/test/java/com/crediya/r2dbc/UserRepositoryAdapterTest.java
+++ b/infrastructure/driven-adapters/r2dbc-postgresql/src/test/java/com/crediya/r2dbc/UserRepositoryAdapterTest.java
@@ -1,0 +1,168 @@
+package com.crediya.r2dbc;
+
+import com.crediya.model.user.User;
+import com.crediya.r2dbc.entity.UserEntity;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.reactivecommons.utils.ObjectMapper;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.times;
+
+@ExtendWith(MockitoExtension.class)
+class UserRepositoryAdapterTest {
+
+	@InjectMocks
+	private UserRepositoryAdapter repositoryAdapter;
+
+	@Mock
+	private IUserRepository repository;
+
+	@Mock
+	private ObjectMapper mapper;
+
+	@Test
+	void shouldSaveUserSuccessfully() {
+		User user = createUser();
+		UserEntity userEntity = createUserEntity();
+
+		when(mapper.map(user, UserEntity.class)).thenReturn(userEntity);
+		when(repository.save(userEntity)).thenReturn(Mono.just(userEntity));
+		when(mapper.map(userEntity, User.class)).thenReturn(user);
+
+		Mono<User> result = repositoryAdapter.save(user);
+
+		StepVerifier.create(result).expectNext(user).verifyComplete();
+
+		verify(mapper).map(user, UserEntity.class);
+		verify(repository).save(userEntity);
+		verify(mapper).map(userEntity, User.class);
+	}
+
+	@Test
+	void shouldReturnErrorWhenRepositorySaveFails() {
+		User user = createUser();
+		UserEntity userEntity = createUserEntity();
+
+		when(mapper.map(user, UserEntity.class)).thenReturn(userEntity);
+		when(repository.save(userEntity)).thenReturn(Mono.error(new RuntimeException("Database error")));
+
+		Mono<User> result = repositoryAdapter.save(user);
+
+		StepVerifier.create(result).expectError(RuntimeException.class).verify();
+
+		verify(mapper).map(user, UserEntity.class);
+		verify(repository).save(userEntity);
+		verify(mapper, times(0)).map(any(UserEntity.class), eq(User.class));
+	}
+
+	@Test
+	void shouldCheckIfEmailExists() {
+		String email = "test@example.com";
+		when(repository.existsByEmail(email)).thenReturn(Mono.just(true));
+
+		Mono<Boolean> result = repositoryAdapter.existsByEmail(email);
+
+		StepVerifier.create(result).expectNext(true).verifyComplete();
+
+		verify(repository).existsByEmail(email);
+	}
+
+	@Test
+	void shouldCheckIfEmailDoesNotExist() {
+		String email = "nonexistent@example.com";
+		when(repository.existsByEmail(email)).thenReturn(Mono.just(false));
+
+		Mono<Boolean> result = repositoryAdapter.existsByEmail(email);
+
+		StepVerifier.create(result).expectNext(false).verifyComplete();
+
+		verify(repository).existsByEmail(email);
+	}
+
+	@Test
+	void shouldReturnErrorWhenExistsByEmailFails() {
+		String email = "test@example.com";
+		when(repository.existsByEmail(email)).thenReturn(Mono.error(new RuntimeException("Database connection error")));
+
+		Mono<Boolean> result = repositoryAdapter.existsByEmail(email);
+
+		StepVerifier.create(result).expectError(RuntimeException.class).verify();
+	}
+
+	@Test
+	void shouldCheckIfDocumentNumberExists() {
+		String documentNumber = "12345678";
+		when(repository.existsByDocumentNumber(documentNumber)).thenReturn(Mono.just(true));
+
+		Mono<Boolean> result = repositoryAdapter.existsByDocumentNumber(documentNumber);
+
+		StepVerifier.create(result).expectNext(true).verifyComplete();
+
+		verify(repository).existsByDocumentNumber(documentNumber);
+	}
+
+	@Test
+	void shouldCheckIfDocumentNumberDoesNotExist() {
+		String documentNumber = "87654321";
+		when(repository.existsByDocumentNumber(documentNumber)).thenReturn(Mono.just(false));
+
+		Mono<Boolean> result = repositoryAdapter.existsByDocumentNumber(documentNumber);
+
+		StepVerifier.create(result).expectNext(false).verifyComplete();
+
+		verify(repository).existsByDocumentNumber(documentNumber);
+	}
+
+	@Test
+	void shouldReturnErrorWhenExistsByDocumentNumberFails() {
+		String documentNumber = "12345678";
+		when(repository.existsByDocumentNumber(documentNumber)).thenReturn(Mono.error(new RuntimeException(
+		 "Database " + "connection error")));
+
+		Mono<Boolean> result = repositoryAdapter.existsByDocumentNumber(documentNumber);
+
+		StepVerifier.create(result).expectError(RuntimeException.class).verify();
+	}
+
+	@Test
+	void shouldHandleNullEmailInExistsCheck() {
+		when(repository.existsByEmail(null)).thenReturn(Mono.error(new IllegalArgumentException("Email cannot be null")));
+
+		Mono<Boolean> result = repositoryAdapter.existsByEmail(null);
+
+		StepVerifier.create(result).expectError(IllegalArgumentException.class).verify();
+	}
+
+	@Test
+	void shouldHandleEmptyEmailInExistsCheck() {
+		when(repository.existsByEmail("")).thenReturn(Mono.just(false));
+
+		Mono<Boolean> result = repositoryAdapter.existsByEmail("");
+
+		StepVerifier.create(result).expectNext(false).verifyComplete();
+	}
+
+	private User createUser() {
+		return User.builder().id(1L).documentNumber("12345678").name("John").lastName("Doe")
+		 .birthDate(LocalDate.of(1990, 1, 1)).address("123 Main St").phone("1234567890").email("john.doe@example.com")
+		 .baseSalary(BigDecimal.valueOf(5000000)).build();
+	}
+
+	private UserEntity createUserEntity() {
+		return UserEntity.builder().id(1L).documentNumber("12345678").name("John").lastName("Doe")
+		 .birthDate(LocalDate.of(1990, 1, 1)).address("123 Main St").phone("1234567890").email("john.doe@example.com")
+		 .baseSalary(BigDecimal.valueOf(5000000)).build();
+	}
+}

--- a/infrastructure/driven-adapters/r2dbc-postgresql/src/test/java/com/crediya/r2dbc/config/PostgreSQLConnectionPoolTest.java
+++ b/infrastructure/driven-adapters/r2dbc-postgresql/src/test/java/com/crediya/r2dbc/config/PostgreSQLConnectionPoolTest.java
@@ -1,0 +1,37 @@
+package com.crediya.r2dbc.config;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.when;
+
+class PostgreSQLConnectionPoolTest {
+
+    @InjectMocks
+    private PostgreSQLConnectionPool connectionPool;
+
+    @Mock
+    private PostgresqlConnectionProperties properties;
+
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+
+        when(properties.host()).thenReturn("localhost");
+        when(properties.port()).thenReturn(5432);
+        when(properties.database()).thenReturn("dbName");
+        when(properties.schema()).thenReturn("schema");
+        when(properties.username()).thenReturn("username");
+        when(properties.password()).thenReturn("password");
+    }
+
+    @Test
+    void getConnectionConfigSuccess() {
+        assertNotNull(connectionPool.getConnectionConfig(properties));
+    }
+}

--- a/infrastructure/driven-adapters/r2dbc-postgresql/src/test/java/com/crediya/r2dbc/helper/ReactiveAdapterOperationsTest.java
+++ b/infrastructure/driven-adapters/r2dbc-postgresql/src/test/java/com/crediya/r2dbc/helper/ReactiveAdapterOperationsTest.java
@@ -1,0 +1,168 @@
+package com.crediya.r2dbc.helper;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.reactivecommons.utils.ObjectMapper;
+import org.springframework.data.domain.Example;
+import org.springframework.data.repository.reactive.ReactiveCrudRepository;
+import org.springframework.data.repository.query.ReactiveQueryByExampleExecutor;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import java.util.Objects;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+class ReactiveAdapterOperationsTest {
+
+    private DummyRepository repository;
+    private ObjectMapper mapper;
+    private ReactiveAdapterOperations<DummyEntity, DummyData, String, DummyRepository> operations;
+
+    @BeforeEach
+    void setUp() {
+        repository = Mockito.mock(DummyRepository.class);
+        mapper = Mockito.mock(ObjectMapper.class);
+        operations = new ReactiveAdapterOperations<DummyEntity, DummyData, String, DummyRepository>(
+                repository, mapper, DummyEntity::toEntity) {};
+    }
+
+    @Test
+    void save() {
+        DummyEntity entity = new DummyEntity("1", "test");
+        DummyData data = new DummyData("1", "test");
+
+        when(mapper.map(entity, DummyData.class)).thenReturn(data);
+        when(repository.save(data)).thenReturn(Mono.just(data));
+
+        StepVerifier.create(operations.save(entity))
+                .expectNext(entity)
+                .verifyComplete();
+    }
+
+    @Test
+    void saveAllEntities() {
+        DummyEntity entity1 = new DummyEntity("1", "test1");
+        DummyEntity entity2 = new DummyEntity("2", "test2");
+        DummyData data1 = new DummyData("1", "test1");
+        DummyData data2 = new DummyData("2", "test2");
+
+        when(mapper.map(entity1, DummyData.class)).thenReturn(data1);
+        when(mapper.map(entity2, DummyData.class)).thenReturn(data2);
+        when(repository.saveAll(any(Flux.class))).thenReturn(Flux.just(data1, data2));
+
+        StepVerifier.create(operations.saveAllEntities(Flux.just(entity1, entity2)))
+                .expectNext(entity1, entity2)
+                .verifyComplete();
+    }
+
+    @Test
+    void findById() {
+        DummyData data = new DummyData("1", "test");
+        DummyEntity entity = new DummyEntity("1", "test");
+
+        when(repository.findById("1")).thenReturn(Mono.just(data));
+
+        StepVerifier.create(operations.findById("1"))
+                .expectNext(entity)
+                .verifyComplete();
+    }
+
+    @Test
+    void findByExample() {
+        DummyEntity entity = new DummyEntity("1", "test");
+        DummyData data = new DummyData("1", "test");
+
+        when(mapper.map(entity, DummyData.class)).thenReturn(data);
+        when(repository.findAll(any(Example.class))).thenReturn(Flux.just(data));
+
+        StepVerifier.create(operations.findByExample(entity))
+                .expectNext(entity)
+                .verifyComplete();
+    }
+
+    @Test
+    void findAll() {
+        DummyData data1 = new DummyData("1", "test1");
+        DummyData data2 = new DummyData("2", "test2");
+        DummyEntity entity1 = new DummyEntity("1", "test1");
+        DummyEntity entity2 = new DummyEntity("2", "test2");
+
+        when(repository.findAll()).thenReturn(Flux.just(data1, data2));
+
+        StepVerifier.create(operations.findAll())
+                .expectNext(entity1, entity2)
+                .verifyComplete();
+    }
+
+    static class DummyEntity {
+        private String id;
+        private String name;
+
+        public DummyEntity(String id, String name) {
+            this.id = id;
+            this.name = name;
+        }
+
+        public static DummyEntity toEntity(DummyData data) {
+            return new DummyEntity(data.getId(), data.getName());
+        }
+
+        public String getId() {
+            return id;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            DummyEntity that = (DummyEntity) o;
+            return id.equals(that.id) && name.equals(that.name);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(id, name);
+        }
+    }
+
+    static class DummyData {
+        private String id;
+        private String name;
+
+        public DummyData(String id, String name) {
+            this.id = id;
+            this.name = name;
+        }
+
+        public String getId() {
+            return id;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            DummyData that = (DummyData) o;
+            return id.equals(that.id) && name.equals(that.name);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(id, name);
+        }
+    }
+
+    interface DummyRepository extends ReactiveCrudRepository<DummyData, String>, ReactiveQueryByExampleExecutor<DummyData> {}
+}

--- a/infrastructure/entry-points/reactive-web/build.gradle
+++ b/infrastructure/entry-points/reactive-web/build.gradle
@@ -1,0 +1,9 @@
+dependencies {
+    implementation project(':usecase')
+    implementation project(':model')
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation 'io.micrometer:micrometer-registry-prometheus'
+    implementation "org.mapstruct:mapstruct:$mapstructVersion"
+    annotationProcessor "org.mapstruct:mapstruct-processor:$mapstructVersion"
+}

--- a/infrastructure/entry-points/reactive-web/build.gradle
+++ b/infrastructure/entry-points/reactive-web/build.gradle
@@ -6,4 +6,6 @@ dependencies {
     implementation 'io.micrometer:micrometer-registry-prometheus'
     implementation "org.mapstruct:mapstruct:$mapstructVersion"
     annotationProcessor "org.mapstruct:mapstruct-processor:$mapstructVersion"
+    implementation 'org.springdoc:springdoc-openapi-starter-webflux-ui:2.3.0'
+    implementation 'org.springdoc:springdoc-openapi-starter-common:2.3.0'
 }

--- a/infrastructure/entry-points/reactive-web/src/main/java/com/crediya/api/Handler.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/com/crediya/api/Handler.java
@@ -1,0 +1,33 @@
+package com.crediya.api;
+
+import com.crediya.api.dto.SaveUserDTO;
+import com.crediya.api.exception.CustomErrorResponse;
+import com.crediya.api.mapper.IUserMapper;
+import com.crediya.model.user.exceptions.ValidationException;
+import com.crediya.usecase.user.UserUseCase;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.server.ServerRequest;
+import org.springframework.web.reactive.function.server.ServerResponse;
+import reactor.core.publisher.Mono;
+
+@Log4j2
+@Component
+@RequiredArgsConstructor
+public class Handler {
+	private final UserUseCase userUseCase;
+	private final IUserMapper userMapper;
+
+	public Mono<ServerResponse> listenSaveUser(ServerRequest serverRequest) {
+		log.info("Consuming path: /api/v1/users");
+		log.info("Starting to process the request to save a user");
+		return serverRequest.bodyToMono(SaveUserDTO.class).map(userMapper::toModel).flatMap(userUseCase::save)
+		 .flatMap(saved -> ServerResponse.status(HttpStatus.CREATED).build())
+		 .onErrorResume(ValidationException.class,
+			ex -> ServerResponse.badRequest().contentType(MediaType.APPLICATION_JSON)
+			.bodyValue(new CustomErrorResponse("VALIDATION_ERROR", ex.getMessage())));
+	}
+}

--- a/infrastructure/entry-points/reactive-web/src/main/java/com/crediya/api/RouterRest.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/com/crediya/api/RouterRest.java
@@ -1,0 +1,22 @@
+package com.crediya.api;
+
+import com.crediya.api.config.UserPaths;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.server.RouterFunction;
+import org.springframework.web.reactive.function.server.ServerResponse;
+
+import static org.springframework.web.reactive.function.server.RequestPredicates.POST;
+import static org.springframework.web.reactive.function.server.RouterFunctions.route;
+
+@Configuration
+@RequiredArgsConstructor
+public class RouterRest {
+	private final UserPaths userPaths;
+
+	@Bean
+	public RouterFunction<ServerResponse> routerFunction(Handler handler) {
+		return route(POST(userPaths.getUser()), handler::listenSaveUser);
+	}
+}

--- a/infrastructure/entry-points/reactive-web/src/main/java/com/crediya/api/RouterRest.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/com/crediya/api/RouterRest.java
@@ -1,9 +1,21 @@
 package com.crediya.api;
 
 import com.crediya.api.config.UserPaths;
+import com.crediya.api.dto.SaveUserDTO;
+import com.crediya.api.exception.CustomErrorResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import lombok.RequiredArgsConstructor;
+import org.springdoc.core.annotations.RouterOperation;
+import org.springdoc.core.annotations.RouterOperations;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.reactive.function.server.RouterFunction;
 import org.springframework.web.reactive.function.server.ServerResponse;
 
@@ -16,6 +28,34 @@ public class RouterRest {
 	private final UserPaths userPaths;
 
 	@Bean
+	@RouterOperations({
+	 @RouterOperation(path = "/api/v1/users", method = RequestMethod.POST, operation = @Operation(operationId =
+		"createUser", summary = "Create a new user", description =
+		"Creates a new user in the system with the provided " + "information", tags = {
+		"User Management"}, requestBody = @RequestBody(description = "User information to create", required = true,
+		content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation =
+		 SaveUserDTO.class), examples = @ExampleObject(name = "User Example", value = """
+		{
+		    "documentNumber": "12345678",
+		    "name": "John",
+		    "lastName": "Doe",
+		    "birthDate": "1990-05-15",
+		    "address": "Calle 123 #45-67, Bogotá",
+		    "phone": "3001234567",
+		    "email": "john.doe@example.com",
+		    "baseSalary": 5000000.00
+		}
+		"""))), responses = {
+		@ApiResponse(responseCode = "201", description = "User created successfully", content = @Content(mediaType =
+		 MediaType.APPLICATION_JSON_VALUE)),
+		@ApiResponse(responseCode = "400", description = "Validation error or bad request", content = @Content(mediaType =
+		 MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = CustomErrorResponse.class), examples =
+		@ExampleObject(name = "Validation Error", value = """
+		 	{
+		 		"code": "VALIDATION_ERROR",
+		 		"message": "Email is already registered"
+		 	}
+		 """)))}))})
 	public RouterFunction<ServerResponse> routerFunction(Handler handler) {
 		return route(POST(userPaths.getUser()), handler::listenSaveUser);
 	}

--- a/infrastructure/entry-points/reactive-web/src/main/java/com/crediya/api/config/CorsConfig.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/com/crediya/api/config/CorsConfig.java
@@ -1,0 +1,29 @@
+package com.crediya.api.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.reactive.CorsWebFilter;
+import org.springframework.web.cors.reactive.UrlBasedCorsConfigurationSource;
+
+import java.util.Arrays;
+import java.util.List;
+
+@Configuration
+public class CorsConfig {
+
+    @Bean
+    CorsWebFilter corsWebFilter(@Value("${cors.allowed-origins}") String origins) {
+        CorsConfiguration config = new CorsConfiguration();
+        config.setAllowCredentials(true);
+        config.setAllowedOrigins(List.of(origins.split(",")));
+        config.setAllowedMethods(Arrays.asList("POST", "GET"));
+        config.setAllowedHeaders(List.of(CorsConfiguration.ALL));
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", config);
+
+        return new CorsWebFilter(source);
+    }
+}

--- a/infrastructure/entry-points/reactive-web/src/main/java/com/crediya/api/config/OpenApiConfig.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/com/crediya/api/config/OpenApiConfig.java
@@ -1,0 +1,26 @@
+package com.crediya.api.config;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.info.Contact;
+import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.annotations.info.License;
+import io.swagger.v3.oas.annotations.servers.Server;
+import org.springdoc.core.models.GroupedOpenApi;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@OpenAPIDefinition(info = @Info(title = "CrediYa Authentication Service API", version = "1.0.0", description = "API " +
+ "for user authentication and management in CrediYa platform", contact = @Contact(name = "CrediYa Development Team",
+ email = "dev@crediya.com"), license = @License(name = "MIT License", url = "https://opensource.org/licenses/MIT")),
+ servers = {
+ @Server(url = "http://localhost:8080", description = "Local Development Server"),
+ @Server(url = "https://api.crediya.com", description = "Production Server")})
+public class OpenApiConfig {
+
+	@Bean
+	public GroupedOpenApi userApi() {
+		return GroupedOpenApi.builder().group("users").displayName("User Management").pathsToMatch("/api/v1/users/**")
+		 .build();
+	}
+}

--- a/infrastructure/entry-points/reactive-web/src/main/java/com/crediya/api/config/SecurityHeadersConfig.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/com/crediya/api/config/SecurityHeadersConfig.java
@@ -1,0 +1,25 @@
+package com.crediya.api.config;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.stereotype.Component;
+import org.springframework.web.server.ServerWebExchange;
+import org.springframework.web.server.WebFilter;
+import org.springframework.web.server.WebFilterChain;
+import reactor.core.publisher.Mono;
+
+@Component
+public class SecurityHeadersConfig implements WebFilter {
+
+    @Override
+    public Mono<Void> filter(ServerWebExchange exchange, WebFilterChain chain) {
+        HttpHeaders headers = exchange.getResponse().getHeaders();
+        headers.set("Content-Security-Policy", "default-src 'self'; frame-ancestors 'self'; form-action 'self'");
+        headers.set("Strict-Transport-Security", "max-age=31536000;");
+        headers.set("X-Content-Type-Options", "nosniff");
+        headers.set("Server", "");
+        headers.set("Cache-Control", "no-store");
+        headers.set("Pragma", "no-cache");
+        headers.set("Referrer-Policy", "strict-origin-when-cross-origin");
+        return chain.filter(exchange);
+    }
+}

--- a/infrastructure/entry-points/reactive-web/src/main/java/com/crediya/api/config/UserPaths.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/com/crediya/api/config/UserPaths.java
@@ -1,0 +1,12 @@
+package com.crediya.api.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@Getter
+@Setter
+@ConfigurationProperties(prefix = "routes.paths")
+public class UserPaths {
+	private String user;
+}

--- a/infrastructure/entry-points/reactive-web/src/main/java/com/crediya/api/dto/SaveUserDTO.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/com/crediya/api/dto/SaveUserDTO.java
@@ -1,0 +1,8 @@
+package com.crediya.api.dto;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+public record SaveUserDTO(String documentNumber, String name, String lastName, LocalDate birthDate, String address,
+													String phone, String email, BigDecimal baseSalary) {
+}

--- a/infrastructure/entry-points/reactive-web/src/main/java/com/crediya/api/dto/SaveUserDTO.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/com/crediya/api/dto/SaveUserDTO.java
@@ -1,8 +1,33 @@
 package com.crediya.api.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.*;
+
 import java.math.BigDecimal;
 import java.time.LocalDate;
 
-public record SaveUserDTO(String documentNumber, String name, String lastName, LocalDate birthDate, String address,
-													String phone, String email, BigDecimal baseSalary) {
+@Schema(title = "Save User DTO", description = "Data Transfer Object for creating a new user")
+public record SaveUserDTO(
+
+ @Schema(description = "User's document number (8 digits)", example = "12345678", pattern = "^\\d{8}$") @NotBlank(message = "Document number is required") @Pattern(regexp = "^\\d{8}$", message = "Document number must be 8 digits") String documentNumber,
+
+ @Schema(description = "User's first name", example = "John", minLength = 1, maxLength = 50) @NotBlank(message =
+	"Name is required") @Size(max = 50, message = "Name must not exceed 50 characters") String name,
+
+ @Schema(description = "User's last name", example = "Doe", minLength = 1, maxLength = 50) @NotBlank(message = "Last " +
+	"name is required") @Size(max = 50, message = "Last name must not exceed 50 characters") String lastName,
+
+ @Schema(description = "User's birth date (must be 18 or older)", example = "1990-05-15") @NotNull(message = "Birth " +
+	"date is required") @Past(message = "Birth date must be in the past") LocalDate birthDate,
+
+ @Schema(description = "User's address", example = "Calle 123 #45-67, Bogotá", maxLength = 200) @NotBlank(message =
+	"Address is required") @Size(max = 200, message = "Address must not exceed 200 characters") String address,
+
+ @Schema(description = "User's phone number", example = "3001234567", pattern = "^[0-9+\\-\\s]+$") @NotBlank(message
+	= "Phone is required") @Pattern(regexp = "^[0-9+\\-\\s]+$", message = "Invalid phone format") String phone,
+
+ @Schema(description = "User's email address", example = "john.doe@example.com") @NotBlank(message = "Email is " +
+	"required") @Email(message = "Invalid email format") String email,
+
+ @Schema(description = "User's base salary in Colombian Pesos", example = "5000000.00", minimum = "1") @NotNull(message = "Base salary is required") @DecimalMin(value = "1", message = "Base salary must be greater than 0") BigDecimal baseSalary) {
 }

--- a/infrastructure/entry-points/reactive-web/src/main/java/com/crediya/api/exception/CustomErrorResponse.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/com/crediya/api/exception/CustomErrorResponse.java
@@ -1,0 +1,11 @@
+package com.crediya.api.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class CustomErrorResponse {
+	private String code;
+	private String message;
+}

--- a/infrastructure/entry-points/reactive-web/src/main/java/com/crediya/api/exception/CustomErrorResponse.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/com/crediya/api/exception/CustomErrorResponse.java
@@ -1,11 +1,17 @@
 package com.crediya.api.exception;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 
 @Data
 @AllArgsConstructor
+@Schema(title = "Error Response", description = "Standard error response format")
 public class CustomErrorResponse {
+
+	@Schema(description = "Error code identifying the type of error", example = "VALIDATION_ERROR")
 	private String code;
+
+	@Schema(description = "Human-readable error message", example = "Email is already registered")
 	private String message;
 }

--- a/infrastructure/entry-points/reactive-web/src/main/java/com/crediya/api/exception/GlobalExceptionHandler.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/com/crediya/api/exception/GlobalExceptionHandler.java
@@ -1,0 +1,17 @@
+package com.crediya.api.exception;
+
+import com.crediya.model.user.exceptions.ValidationException;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Log4j2
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+	@ExceptionHandler(ValidationException.class)
+	public ResponseEntity<CustomErrorResponse> handleValidation(ValidationException ex) {
+		log.error("Validation error: {}", ex.getMessage());
+		return ResponseEntity.badRequest().body(new CustomErrorResponse("VALIDATION_ERROR", ex.getMessage()));
+	}
+}

--- a/infrastructure/entry-points/reactive-web/src/main/java/com/crediya/api/mapper/IUserMapper.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/com/crediya/api/mapper/IUserMapper.java
@@ -1,0 +1,10 @@
+package com.crediya.api.mapper;
+
+import com.crediya.api.dto.SaveUserDTO;
+import com.crediya.model.user.User;
+import org.mapstruct.Mapper;
+
+@Mapper(componentModel = "spring")
+public interface IUserMapper {
+	User toModel(SaveUserDTO saveUserDTO);
+}

--- a/infrastructure/entry-points/reactive-web/src/test/java/com/crediya/api/RouterRestTest.java
+++ b/infrastructure/entry-points/reactive-web/src/test/java/com/crediya/api/RouterRestTest.java
@@ -1,0 +1,130 @@
+package com.crediya.api;
+
+import com.crediya.api.config.UserPaths;
+import com.crediya.api.dto.SaveUserDTO;
+import com.crediya.api.mapper.IUserMapper;
+import com.crediya.model.user.User;
+import com.crediya.model.user.exceptions.ValidationException;
+import com.crediya.usecase.user.UserUseCase;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.reactive.WebFluxTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.reactive.server.WebTestClient;
+import reactor.core.publisher.Mono;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ContextConfiguration(classes = {RouterRest.class, Handler.class, UserPaths.class})
+@WebFluxTest
+@TestPropertySource(properties = {"routes.paths.user=/api/v1/users"})
+class RouterRestTest {
+
+	@Autowired
+	private WebTestClient webTestClient;
+
+	@MockitoBean
+	private UserUseCase userUseCase;
+
+	@MockitoBean
+	private IUserMapper userMapper;
+
+	private ObjectMapper objectMapper;
+
+	@BeforeEach
+	void setUp() {
+		objectMapper = new ObjectMapper();
+		objectMapper.registerModule(new JavaTimeModule());
+	}
+
+	@Test
+	void shouldCreateUserSuccessfully() throws JsonProcessingException {
+		SaveUserDTO saveUserDTO =
+		 new SaveUserDTO("12345678", "John", "Doe", LocalDate.of(1990, 1, 1), "123 Main St", "1234567890",
+			"john" + ".doe@example.com", BigDecimal.valueOf(5000000));
+
+		User user =
+		 User.builder().documentNumber("12345678").name("John").lastName("Doe").birthDate(LocalDate.of(1990, 1, 1))
+			.address("123 Main St").phone("1234567890").email("john.doe@example.com").baseSalary(BigDecimal.valueOf(5000000))
+			.build();
+
+		User savedUser = user.toBuilder().id(1L).build();
+
+		when(userMapper.toModel(any(SaveUserDTO.class))).thenReturn(user);
+		when(userUseCase.save(any(User.class))).thenReturn(Mono.just(savedUser));
+
+		webTestClient.post().uri("/api/v1/users").contentType(MediaType.APPLICATION_JSON)
+		 .bodyValue(objectMapper.writeValueAsString(saveUserDTO)).exchange().expectStatus().isCreated();
+	}
+
+	@Test
+	void shouldReturnBadRequestWhenValidationFails() throws JsonProcessingException {
+		SaveUserDTO saveUserDTO =
+		 new SaveUserDTO("12345678", "", "Doe", LocalDate.of(1990, 1, 1), "123 Main St", "1234567890",
+			"john.doe@example" + ".com", BigDecimal.valueOf(5000000));
+
+		User user = User.builder().documentNumber("12345678").name("").lastName("Doe").birthDate(LocalDate.of(1990, 1, 1))
+		 .address("123 Main St").phone("1234567890").email("john.doe@example.com").baseSalary(BigDecimal.valueOf(5000000))
+		 .build();
+
+		when(userMapper.toModel(any(SaveUserDTO.class))).thenReturn(user);
+		when(userUseCase.save(any(User.class))).thenReturn(Mono.error(new ValidationException("Name is required")));
+
+		webTestClient.post().uri("/api/v1/users").contentType(MediaType.APPLICATION_JSON)
+		 .bodyValue(objectMapper.writeValueAsString(saveUserDTO)).exchange().expectStatus().isBadRequest();
+	}
+
+	@Test
+	void shouldReturnBadRequestWhenEmailAlreadyExists() throws JsonProcessingException {
+		SaveUserDTO saveUserDTO =
+		 new SaveUserDTO("12345678", "John", "Doe", LocalDate.of(1990, 1, 1), "123 Main St", "1234567890",
+			"existing" + "@example.com", BigDecimal.valueOf(5000000));
+
+		User user =
+		 User.builder().documentNumber("12345678").name("John").lastName("Doe").birthDate(LocalDate.of(1990, 1, 1))
+			.address("123 Main St").phone("1234567890").email("existing@example.com").baseSalary(BigDecimal.valueOf(5000000))
+			.build();
+
+		when(userMapper.toModel(any(SaveUserDTO.class))).thenReturn(user);
+		when(userUseCase.save(any(User.class))).thenReturn(Mono.error(new ValidationException(
+		 "Email is already " + "registered")));
+
+		webTestClient.post().uri("/api/v1/users").contentType(MediaType.APPLICATION_JSON)
+		 .bodyValue(objectMapper.writeValueAsString(saveUserDTO)).exchange().expectStatus().isBadRequest();
+	}
+
+	@Test
+	void shouldReturnBadRequestForInvalidJsonBody() {
+		webTestClient.post().uri("/api/v1/users").contentType(MediaType.APPLICATION_JSON).bodyValue("{invalid json}")
+		 .exchange().expectStatus().isBadRequest();
+	}
+
+	@Test
+	void shouldReturnBadRequestForEmptyBody() {
+		webTestClient.post().uri("/api/v1/users").contentType(MediaType.APPLICATION_JSON).bodyValue("").exchange()
+		 .expectStatus().isBadRequest();
+	}
+
+	@Test
+	void shouldReturnInternalServerErrorForUnexpectedErrors() throws JsonProcessingException {
+		SaveUserDTO saveUserDTO =
+		 new SaveUserDTO("12345678", "John", "Doe", LocalDate.of(1990, 1, 1), "123 Main St", "1234567890",
+			"john" + ".doe@example.com", BigDecimal.valueOf(5000000));
+
+		when(userMapper.toModel(any(SaveUserDTO.class))).thenThrow(new RuntimeException("Unexpected error"));
+
+		webTestClient.post().uri("/api/v1/users").contentType(MediaType.APPLICATION_JSON)
+		 .bodyValue(objectMapper.writeValueAsString(saveUserDTO)).exchange().expectStatus().is5xxServerError();
+	}
+}

--- a/infrastructure/entry-points/reactive-web/src/test/java/com/crediya/api/config/ConfigTest.java
+++ b/infrastructure/entry-points/reactive-web/src/test/java/com/crediya/api/config/ConfigTest.java
@@ -1,0 +1,63 @@
+package com.crediya.api.config;
+
+import com.crediya.api.Handler;
+import com.crediya.api.RouterRest;
+import com.crediya.api.dto.SaveUserDTO;
+import com.crediya.api.mapper.IUserMapper;
+import com.crediya.model.user.User;
+import com.crediya.usecase.user.UserUseCase;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.reactive.WebFluxTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.reactive.server.WebTestClient;
+import reactor.core.publisher.Mono;
+import org.springframework.http.MediaType;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+import static org.mockito.Mockito.when;
+
+@ContextConfiguration(classes = {RouterRest.class, Handler.class, UserPaths.class})
+@WebFluxTest
+@Import({CorsConfig.class, SecurityHeadersConfig.class})
+@TestPropertySource(properties = {"routes.paths.user=/api/v1/users"})
+class ConfigTest {
+
+	@Autowired
+	private WebTestClient webTestClient;
+
+	@MockitoBean
+	private UserUseCase userUseCase;
+
+	@MockitoBean
+	private IUserMapper userMapper;
+
+	private final User user = User.builder().id(1L).documentNumber("12345678").name("John").lastName("Doe").build();
+
+	private final SaveUserDTO saveUserDTO =
+	 new SaveUserDTO("12345678", "John", "Doe", LocalDate.of(1990, 5, 15), "Calle 123 #45-67, Bogotá", "3001234567",
+		"juan" + ".perez7@email.com", BigDecimal.valueOf(5000000.00));
+
+	@BeforeEach
+	void setUp() {
+		when(userUseCase.save(user)).thenReturn(Mono.just(user));
+		when(userMapper.toModel(saveUserDTO)).thenReturn(user);
+	}
+
+	@Test
+	void corsConfigurationShouldAllowOrigins() {
+		webTestClient.post().uri("/api/v1/users").contentType(MediaType.APPLICATION_JSON).bodyValue(saveUserDTO).exchange()
+		 .expectStatus().isCreated().expectHeader()
+		 .valueEquals("Content-Security-Policy", "default-src 'self'; frame-ancestors 'self'; form-action 'self'")
+		 .expectHeader().valueEquals("Strict-Transport-Security", "max-age=31536000;").expectHeader()
+		 .valueEquals("X-Content-Type-Options", "nosniff").expectHeader().valueEquals("Server", "").expectHeader()
+		 .valueEquals("Cache-Control", "no-store").expectHeader().valueEquals("Pragma", "no-cache").expectHeader()
+		 .valueEquals("Referrer-Policy", "strict-origin-when-cross-origin");
+	}
+}

--- a/infrastructure/entry-points/reactive-web/src/test/java/com/crediya/api/mapper/UserMapperTest.java
+++ b/infrastructure/entry-points/reactive-web/src/test/java/com/crediya/api/mapper/UserMapperTest.java
@@ -1,0 +1,115 @@
+package com.crediya.api.mapper;
+
+import com.crediya.api.dto.SaveUserDTO;
+import com.crediya.model.user.User;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(classes = {IUserMapperImpl.class})
+class UserMapperTest {
+
+	@Autowired
+	private IUserMapper userMapper;
+
+	@Test
+	void shouldMapSaveUserDTOToUser() {
+		SaveUserDTO saveUserDTO =
+		 new SaveUserDTO("12345678", "John", "Doe", LocalDate.of(1990, 5, 15), "Calle 123 #45-67, Bogotá", "3001234567",
+			"john.doe@example.com", BigDecimal.valueOf(5000000.00));
+
+		User user = userMapper.toModel(saveUserDTO);
+
+		assertThat(user).isNotNull();
+		assertThat(user.getDocumentNumber()).isEqualTo("12345678");
+		assertThat(user.getName()).isEqualTo("John");
+		assertThat(user.getLastName()).isEqualTo("Doe");
+		assertThat(user.getBirthDate()).isEqualTo(LocalDate.of(1990, 5, 15));
+		assertThat(user.getAddress()).isEqualTo("Calle 123 #45-67, Bogotá");
+		assertThat(user.getPhone()).isEqualTo("3001234567");
+		assertThat(user.getEmail()).isEqualTo("john.doe@example.com");
+		assertThat(user.getBaseSalary()).isEqualTo(BigDecimal.valueOf(5000000.00));
+		assertThat(user.getId()).isNull(); // ID should not be mapped from DTO
+	}
+
+	@Test
+	void shouldMapSaveUserDTOWithNullValues() {
+		SaveUserDTO saveUserDTO = new SaveUserDTO(null, null, null, null, null, null, null, null);
+
+		User user = userMapper.toModel(saveUserDTO);
+
+		assertThat(user).isNotNull();
+		assertThat(user.getDocumentNumber()).isNull();
+		assertThat(user.getName()).isNull();
+		assertThat(user.getLastName()).isNull();
+		assertThat(user.getBirthDate()).isNull();
+		assertThat(user.getAddress()).isNull();
+		assertThat(user.getPhone()).isNull();
+		assertThat(user.getEmail()).isNull();
+		assertThat(user.getBaseSalary()).isNull();
+		assertThat(user.getId()).isNull();
+	}
+
+	@Test
+	void shouldMapSaveUserDTOWithMinimalData() {
+		SaveUserDTO saveUserDTO =
+		 new SaveUserDTO("87654321", "Jane", "Smith", LocalDate.of(1985, 12, 25), "Main St 456", "9876543210", "jane" +
+			".smith@test.com", BigDecimal.valueOf(3000000.50));
+
+		User user = userMapper.toModel(saveUserDTO);
+
+		assertThat(user).isNotNull();
+		assertThat(user.getDocumentNumber()).isEqualTo("87654321");
+		assertThat(user.getName()).isEqualTo("Jane");
+		assertThat(user.getLastName()).isEqualTo("Smith");
+		assertThat(user.getBirthDate()).isEqualTo(LocalDate.of(1985, 12, 25));
+		assertThat(user.getAddress()).isEqualTo("Main St 456");
+		assertThat(user.getPhone()).isEqualTo("9876543210");
+		assertThat(user.getEmail()).isEqualTo("jane.smith@test.com");
+		assertThat(user.getBaseSalary()).isEqualTo(BigDecimal.valueOf(3000000.50));
+		assertThat(user.getId()).isNull();
+	}
+
+	@Test
+	void shouldMapSaveUserDTOWithEmptyStrings() {
+		SaveUserDTO saveUserDTO = new SaveUserDTO("", "", "", LocalDate.of(2000, 1, 1), "", "", "", BigDecimal.ZERO);
+
+		User user = userMapper.toModel(saveUserDTO);
+
+		assertThat(user).isNotNull();
+		assertThat(user.getDocumentNumber()).isEqualTo("");
+		assertThat(user.getName()).isEqualTo("");
+		assertThat(user.getLastName()).isEqualTo("");
+		assertThat(user.getBirthDate()).isEqualTo(LocalDate.of(2000, 1, 1));
+		assertThat(user.getAddress()).isEqualTo("");
+		assertThat(user.getPhone()).isEqualTo("");
+		assertThat(user.getEmail()).isEqualTo("");
+		assertThat(user.getBaseSalary()).isEqualTo(BigDecimal.ZERO);
+		assertThat(user.getId()).isNull();
+	}
+
+	@Test
+	void shouldHandleSpecialCharactersInMapping() {
+		SaveUserDTO saveUserDTO =
+		 new SaveUserDTO("12345678", "José María", "González-Pérez", LocalDate.of(1992, 3, 8), "Carrera 7 #32-16, Apt. " +
+			"501", "+57 301 234 5678", "jose.gonzalez@correo.co", BigDecimal.valueOf(4500000.99));
+
+		User user = userMapper.toModel(saveUserDTO);
+
+		assertThat(user).isNotNull();
+		assertThat(user.getDocumentNumber()).isEqualTo("12345678");
+		assertThat(user.getName()).isEqualTo("José María");
+		assertThat(user.getLastName()).isEqualTo("González-Pérez");
+		assertThat(user.getBirthDate()).isEqualTo(LocalDate.of(1992, 3, 8));
+		assertThat(user.getAddress()).isEqualTo("Carrera 7 #32-16, Apt. 501");
+		assertThat(user.getPhone()).isEqualTo("+57 301 234 5678");
+		assertThat(user.getEmail()).isEqualTo("jose.gonzalez@correo.co");
+		assertThat(user.getBaseSalary()).isEqualTo(BigDecimal.valueOf(4500000.99));
+		assertThat(user.getId()).isNull();
+	}
+}

--- a/main.gradle
+++ b/main.gradle
@@ -17,8 +17,8 @@ subprojects {
     compileJava.dependsOn validateStructure
 
     java {
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
+        sourceCompatibility = JavaVersion.VERSION_21
+        targetCompatibility = JavaVersion.VERSION_21
     }
 
     //build.dependsOn 'pitest'

--- a/settings.gradle
+++ b/settings.gradle
@@ -20,3 +20,7 @@ include ':usecase'
 project(':app-service').projectDir = file('./applications/app-service')
 project(':model').projectDir = file('./domain/model')
 project(':usecase').projectDir = file('./domain/usecase')
+include ':r2dbc-postgresql'
+project(':r2dbc-postgresql').projectDir = file('./infrastructure/driven-adapters/r2dbc-postgresql')
+include ':reactive-web'
+project(':reactive-web').projectDir = file('./infrastructure/entry-points/reactive-web')


### PR DESCRIPTION
### Summary
Implements the user registration flow in the Authentication service.

### Changes
- Added User domain model and repository/usecase contracts.
- Implemented RegisterUserUseCase with email and document number uniqueness rule.
- Added R2DBC adapter.
- Created POST /api/v1/usuarios controller with Bean Validation.
- Implemented GlobalExceptionHandler for 400 Bad Request responses.
- Added WebTestClient + unit tests.

### Definition of Done
- [x] User can be registered with name, lastname, birthdate, address, phone, email, baseSalary.
- [x] Validations: non-null fields, email format, salary range 0..15,000,000.
- [x] Email and document number uniqueness validated at DB and usecase level.
- [x] Transactional persistence using R2DBC.
- [x] Swagger docs updated.
- [x] Tests pass (`./gradlew test`).

Closes #3 